### PR TITLE
fix(epic): Integrate design system and UX strategy docs at epic level

### DIFF
--- a/.cursor/commands/epic-journey.md
+++ b/.cursor/commands/epic-journey.md
@@ -23,10 +23,20 @@ If missing: "Which project and epic should I map the user journey for?"
 
 ### Step 1: Understand Journey Context
 
-Load epic and project information:
+**Determine PROJECT_ID** from epic path (e.g., `specs/projects/001-myproject/epics/...`).
+
+**Load required design context**:
+- `specs/projects/[PROJECT_ID]/ux-strategy.md` → UX principles, voice/tone, emotional design goals
+  - Extract: Design principles, user personas, emotional journey targets, accessibility standards
+  - If missing: WARN "No UX strategy found. Run `/project-ux` for UX guidelines that inform journey mapping."
+
+- `specs/projects/[PROJECT_ID]/design-system.md` → Design tokens, interaction patterns
+  - Extract: Interaction patterns, feedback mechanisms, animation guidelines
+  - If missing: Note that touchpoint design will need alignment later
+
+**Load epic context**:
 - Epic specification for scope
-- Project UX strategy for principles
-- User personas from project spec
+- User personas from project spec (referenced in ux-strategy.md)
 
 ### Step 2: Journey Discovery
 

--- a/.cursor/commands/epic-wireframes.md
+++ b/.cursor/commands/epic-wireframes.md
@@ -23,11 +23,20 @@ Ask: "Which project and epic should I create wireframes for?"
 
 ### Step 1: Load Context
 
-Gather necessary information:
-- User journey map (for touchpoints)
-- Design system (for components)
-- Epic specification (for requirements)
-- Project UX strategy (for principles)
+**Determine PROJECT_ID** from epic path (e.g., `specs/projects/001-myproject/epics/...`).
+
+**Load required design context**:
+- `specs/projects/[PROJECT_ID]/design-system.md` → Design tokens, components, patterns
+  - Extract: Color tokens, typography scale, spacing system, component library, grid specifications
+  - If missing: WARN "No design system found. Run `/project-design-system` for consistent wireframes."
+
+- `specs/projects/[PROJECT_ID]/ux-strategy.md` → UX principles, voice/tone
+  - Extract: Design principles, voice attributes, accessibility standards, content guidelines
+  - If missing: WARN "No UX strategy found. Run `/project-ux` for UX guidelines."
+
+**Load epic context**:
+- User journey map (for touchpoints) - `[EPIC_DIR]/user-journey.md`
+- Epic specification (for requirements) - `[EPIC_DIR]/epic.md`
 
 ### Step 2: Screen Discovery
 

--- a/.speck/templates/epic/journey-template.md
+++ b/.speck/templates/epic/journey-template.md
@@ -7,6 +7,19 @@
 
 ---
 
+## 📊 Design Context Sources
+
+**This user journey uses principles from**:
+
+| Document | Path | Key Sections Used |
+|----------|------|-------------------|
+| UX Strategy | `specs/projects/[PROJECT_ID]/ux-strategy.md` | [Personas, Principles, Emotional Goals] |
+| Design System | `specs/projects/[PROJECT_ID]/design-system.md` | [Interaction Patterns, Feedback] |
+
+**If documents missing**: Run `/project-ux` and `/project-design-system` for consistent journey design.
+
+---
+
 ## 📋 Journey Overview
 
 **Persona**: [Primary user type for this journey]  

--- a/.speck/templates/epic/wireframes-template.md
+++ b/.speck/templates/epic/wireframes-template.md
@@ -7,6 +7,20 @@
 
 ---
 
+## 📊 Design Context Sources
+
+**These wireframes use tokens and patterns from**:
+
+| Document | Path | Key Sections Used |
+|----------|------|-------------------|
+| Design System | `specs/projects/[PROJECT_ID]/design-system.md` | [Tokens, Components, Grid] |
+| UX Strategy | `specs/projects/[PROJECT_ID]/ux-strategy.md` | [Principles, Voice/Tone, Accessibility] |
+| User Journey | `[EPIC_DIR]/user-journey.md` | [Touchpoints, Emotional Arc] |
+
+**If documents missing**: Run `/project-design-system` and `/project-ux` for consistency.
+
+---
+
 ## 📱 Screen Inventory
 
 Based on the user journey, this epic requires the following screens:
@@ -24,16 +38,26 @@ Based on the user journey, this epic requires the following screens:
 
 ## 🎨 Design System Application
 
-**Components Used**:
+**Source**: Reference `specs/projects/[PROJECT_ID]/design-system.md`
+
+**Components Used** (from design-system.md component library):
 - Navigation: [Component names from design system]
 - Forms: [Component names]
 - Data Display: [Component names]
 - Feedback: [Component names]
 - Layout: [Component names]
 
+**Design Tokens Applied**:
+- Colors: [Token names used, e.g., `primary-500`, `surface-100`]
+- Typography: [Token names, e.g., `heading-lg`, `body-md`]
+- Spacing: [Token names, e.g., `space-4`, `space-8`]
+- Radius: [Token names, e.g., `radius-md`, `radius-lg`]
+
 **Custom Components Needed**:
+- [Component]: [Why it's unique to this epic - will be added to design-system.md after validation]
 - [Component]: [Why it's unique to this epic]
-- [Component]: [Why it's unique to this epic]
+
+**⚠️ CRITICAL**: Use existing components from design-system.md before creating custom ones.
 
 ---
 
@@ -211,8 +235,12 @@ Legend:
 ## 📝 Content Guidelines
 
 ### Tone & Voice
-- [How content should sound in this epic]
-- [Specific terminology to use/avoid]
+
+**Source**: Reference `specs/projects/[PROJECT_ID]/ux-strategy.md` Voice & Tone section
+
+- Voice: [Extract from ux-strategy.md, e.g., "Friendly but not casual"]
+- Tone adjustments: [How tone changes by context - align with ux-strategy.md]
+- Terminology: [Specific terms to use/avoid - per ux-strategy.md content guidelines]
 
 ### Microcopy
 - **Empty States**: "[Message when no data]"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -509,16 +509,23 @@ Follow design system rules (if project has them):
 - Check accessibility requirements (WCAG standards if specified)
 - Check project Cursor rules for design system enforcement (if present)
 
-### Design Context Loading (CRITICAL for UI Stories!)
-Before planning or implementing UI stories, ALWAYS load project design context:
+### Design Context Loading (CRITICAL for UI Work!)
 
-**Required Documents** (for UI/UX stories):
+Before planning or implementing UI work at ANY level, ALWAYS load project design context:
+
+**Required Documents**:
 ```
 specs/projects/[PROJECT_ID]/design-system.md  → Tokens, components, patterns
 specs/projects/[PROJECT_ID]/ux-strategy.md    → UX principles, voice/tone
 ```
 
-**Loading Checklist**:
+**Epic-Level Loading** (for `/epic-journey`, `/epic-wireframes`):
+- [ ] Load ux-strategy.md for personas, emotional goals, accessibility standards
+- [ ] Load design-system.md for components, tokens, interaction patterns
+- [ ] Apply voice/tone from ux-strategy.md to journey touchpoints and wireframe content
+- [ ] Use design tokens in wireframe specifications
+
+**Story-Level Loading** (for `/story-plan`, `/story-ui-spec`):
 - [ ] Extract design tokens (colors, typography, spacing) from design-system.md
 - [ ] Note available components before creating new ones
 - [ ] Apply voice/tone from ux-strategy.md to copy/microcopy
@@ -530,6 +537,8 @@ specs/projects/[PROJECT_ID]/ux-strategy.md    → UX principles, voice/tone
 - ❌ Creating custom button when Button exists in design-system.md
 - ❌ Using `color: #3B82F6` instead of `color: var(--primary-500)`
 - ❌ Writing generic "Loading..." when ux-strategy.md specifies friendly voice
+- ❌ Designing wireframes without referencing design-system.md grid/spacing
+- ❌ Creating journey maps without ux-strategy.md emotional goals
 
 ## 📊 Learning Capture System (CRITICAL for Retrospectives!)
 


### PR DESCRIPTION
## Summary

This PR ensures epic-level UX commands (`/epic-journey`, `/epic-wireframes`) explicitly load and reference project-level design documents (`ux-strategy.md`, `design-system.md`) for consistency.

This is a follow-up to PR #4 which added the same integration at the story level.

## Changes

### Commands Updated

| Command | Changes |
|---------|---------|
| `epic-journey.md` | Added explicit loading of `ux-strategy.md` (personas, emotional goals) and `design-system.md` (interaction patterns) with file paths and extraction guidance |
| `epic-wireframes.md` | Added explicit loading with file paths, extraction guidance, and WARN messages when docs missing |

### Templates Updated

| Template | Changes |
|----------|---------|
| `journey-template.md` | Added "Design Context Sources" section at top referencing both project docs |
| `wireframes-template.md` | Added "Design Context Sources" section + enhanced "Design System Application" with explicit token references and CRITICAL warning about using existing components |

### Documentation Updated

| File | Changes |
|------|---------|
| `AGENTS.md` | Expanded "Design Context Loading" section to cover both epic-level and story-level loading checklists, added epic-specific anti-patterns |

## Why This Matters

Before this change, epic-level commands mentioned loading "design system" and "UX strategy" conceptually, but didn't specify:
- Exact file paths (`specs/projects/[PROJECT_ID]/design-system.md`)
- What to extract from each document
- Warning behavior when documents are missing

This creates consistency with the story-level integration and ensures the design cascade works properly:
```
Project Level → ux-strategy.md, design-system.md (source of truth)
    ↓
Epic Level → user-journey.md, wireframes.md (apply project tokens/principles)
    ↓
Story Level → plan.md, ui-spec.md (use specific tokens/components)
```

## Testing

- [x] Verified command files have valid markdown structure
- [x] Verified template files have valid markdown structure
- [x] Verified AGENTS.md section is properly formatted