### PR TITLE
fix(sync): improve template-sync docs and fix workflow permission

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -10,8 +10,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  # Note: Modifying workflow files requires a PAT with 'workflow' scope, not a permission here.
-  # The template-sync.yml is excluded via .templatesyncignore to avoid this issue.
 
 jobs:
   repo-sync:
@@ -33,7 +31,6 @@ jobs:
       - name: actions-template-sync
         uses: AndreasAugustin/actions-template-sync@v2.5.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: ${{ secrets.TEMPLATE_SYNC_SOURCE_REPO }}
           upstream_branch: ${{ secrets.TEMPLATE_SYNC_UPSTREAM_BRANCH || 'main' }}
           pr_labels: template_sync,speck

--- a/.speck/TEMPLATE-SYNC.md
+++ b/.speck/TEMPLATE-SYNC.md
@@ -22,9 +22,16 @@ Sync behavior is controlled by `.templatesyncignore` (ignore patterns).
 ## Setup in a product repo
 
 1. **Enable the workflow** (it is already included via the template).
-2. Add repository secret:
-   - **`TEMPLATE_SYNC_SOURCE_REPO`**: `<owner>/<template-repo>`
-3. Optional secret:
+
+2. **Enable PR creation permission** (required):
+   - Go to **Settings → Actions → General → Workflow permissions**
+   - Check ✅ **"Allow GitHub Actions to create and approve pull requests"**
+   - Without this, the sync will fail with: `GitHub Actions is not permitted to create or approve pull requests`
+
+3. Add repository secret:
+   - **`TEMPLATE_SYNC_SOURCE_REPO`**: `<owner>/<template-repo>` (e.g., `telum-ai/speck`)
+
+4. Optional secret:
    - **`TEMPLATE_SYNC_UPSTREAM_BRANCH`**: defaults to `main`
 
 Then either wait for the schedule or run the workflow manually via **Actions → Template Sync (Speck)**.
@@ -53,5 +60,19 @@ If you need to change a template-managed file:
 - **Preferred**: make the change in the template repo and let it sync everywhere.
 - **Escape hatch**: add that file path to `.templatesyncignore` in the product repo.
   - Trade-off: you stop receiving template updates for that file.
+
+## Troubleshooting
+
+### "GitHub Actions is not permitted to create or approve pull requests"
+
+The workflow ran but failed to create a PR. Fix:
+1. Go to **Settings → Actions → General → Workflow permissions**
+2. Check ✅ **"Allow GitHub Actions to create and approve pull requests"**
+
+### "TEMPLATE_SYNC_SOURCE_REPO not set. Skipping template sync."
+
+This is expected if you haven't configured the secret yet. Add it:
+1. Go to **Settings → Secrets and variables → Actions**
+2. Add secret: `TEMPLATE_SYNC_SOURCE_REPO` = `<owner>/<template-repo>`
 
 


### PR DESCRIPTION
## Summary

Improves template sync documentation based on real-world usage issues.

## Changes

### `.templatesyncignore`
- Added `.github/workflows/template-sync.yml` to prevent the workflow from trying to sync itself (which fails due to workflow permission requirements)

### `.speck/TEMPLATE-SYNC.md`
- Added required step: Enable "Allow GitHub Actions to create and approve pull requests" in repo settings
- Added troubleshooting section for common errors:
  - "GitHub Actions is not permitted to create or approve pull requests"
  - "TEMPLATE_SYNC_SOURCE_REPO not set"

## Context

The template sync workflow was failing in product repos because:
1. It tried to update the `template-sync.yml` file itself (requires PAT with `workflow` scope)
2. The repo setting for PR creation wasn't enabled

This PR addresses both issues with documentation and ignore patterns.