### PR TITLE
Add a project-local learnings register flow to Speck

### DIFF
--- a/.cursor/skills/epic-retrospective/SKILL.md
+++ b/.cursor/skills/epic-retrospective/SKILL.md
@@ -3,6 +3,10 @@ name: epic-retrospective
 description: Load after epic-validate passes to synthesize all story-retro.md files, validate cross-story patterns, and produce epic-retro.md. Feeds the project retrospective — run after every completed epic. FIRST ACTION after loading: read template at .speck/templates/epic/epic-retro-template.md before any context loading or artifact generation.
 disable-model-invocation: false
 ---
+## Learnings register propagation
+
+When synthesizing an epic retrospective, update the project-local `learnings-register.md` with validated patterns, gotchas, and next verification targets that should shape upcoming stories or epics.
+
 
 
 The user input to you can be provided directly by the agent or as a command argument - you **MUST** consider it before proceeding with the prompt (if not empty).

--- a/.cursor/skills/project-retrospective/SKILL.md
+++ b/.cursor/skills/project-retrospective/SKILL.md
@@ -3,6 +3,10 @@ name: project-retrospective
 description: Load after project-validate passes to synthesize all epic retrospectives, validate cross-project patterns, and evolve the Speck methodology. Run once at project completion. FIRST ACTION after loading: read template at .speck/templates/project/project-retro-template.md before any context loading or artifact generation.
 disable-model-invocation: false
 ---
+## Learnings register propagation
+
+When synthesizing a project retrospective, update `specs/projects/[project-id]/learnings-register.md` alongside the retrospective. Promote stable cross-epic lessons there before proposing upstream methodology changes.
+
 
 
 The user input to you can be provided directly by the agent or as a command argument - you **MUST** consider it before proceeding with the prompt (if not empty).

--- a/.cursor/skills/speck-learn/SKILL.md
+++ b/.cursor/skills/speck-learn/SKILL.md
@@ -3,6 +3,10 @@ name: speck-learn
 description: Load to capture a quick learning, pattern, or insight outside the formal retrospective process. Use for mid-story discoveries, surprising gotchas, or performance insights that shouldn't wait until story completion.
 disable-model-invocation: false
 ---
+## Learnings register propagation
+
+`/speck-learn` should update the project-local `learnings-register.md` first. Only promote a learning into broader pattern libraries after it has evidence beyond a single isolated event.
+
 
 
 The user input to you can be provided directly by the agent or as a command argument - you **MUST** consider it before proceeding with the prompt (if not empty).

--- a/.cursor/skills/story-retrospective/SKILL.md
+++ b/.cursor/skills/story-retrospective/SKILL.md
@@ -3,6 +3,10 @@ name: story-retrospective
 description: Load after story-validate produces a PASS result to mine git commits and produce story-retro.md. Run after every completed story — essential for feeding learnings into the epic retrospective and improving future stories. FIRST ACTION after loading: read template at .speck/templates/story/story-retro-template.md before any context loading or artifact generation.
 disable-model-invocation: false
 ---
+## Learnings register propagation
+
+When synthesizing a story retrospective, update the project-local `learnings-register.md` with any pattern, gotcha, or hypothesis worth carrying into the next story. Keep one-off noise out; capture durable signal.
+
 
 
 The user input to you can be provided directly by the agent or as a command argument - you **MUST** consider it before proceeding with the prompt (if not empty).

--- a/.speck/patterns/learned/README.md
+++ b/.speck/patterns/learned/README.md
@@ -100,3 +100,8 @@ This ensures only **truly validated** patterns make it into the library.
 **Version**: 1.0  
 **Updated**: 2025-12-20
 
+
+
+## Relationship to project-local learnings
+
+Project retrospectives and `/speck-learn` should first update the project-local `learnings-register.md`. Patterns graduate into this library only after they prove reusable beyond a single story or isolated incident.

--- a/.speck/templates/epic/epic-retro-template.md
+++ b/.speck/templates/epic/epic-retro-template.md
@@ -130,6 +130,13 @@
 
 ---
 
+## Promotion to Learnings Register
+
+Update the project-local `learnings-register.md` with:
+- validated patterns that showed up across stories
+- systemic gotchas the next epic must not repeat
+- retired learnings that no longer apply
+
 ## Immediate Actions (Non-Meta - Applied to Current Project)
 
 > **These updates were made during this retrospective**

--- a/.speck/templates/project/learnings-register-template.md
+++ b/.speck/templates/project/learnings-register-template.md
@@ -1,0 +1,41 @@
+# Learnings Register: [Project Name]
+
+**Project**: [Project Name]
+**Last Updated**: [DATE]
+**Purpose**: Durable project-local learnings that should shape future planning, implementation, and retrospectives. This is the staging surface between one-off retrospective notes and fully promoted reusable patterns.
+
+## Active Learnings
+
+| ID | Type | Learning | Confidence | Source | Next verification target |
+|----|------|----------|------------|--------|--------------------------|
+| L001 | Pattern / Gotcha / UX / Delivery / Validation | [What we learned] | [Low/Med/High] | [Story/Epic/Project retro or /speck-learn] | [Where to verify next] |
+
+## Promoted Patterns
+
+List learnings that are now stable enough to influence multiple future stories in this project.
+
+- **Pattern**: [Reusable approach]
+  - **Evidence**: [Where it proved out]
+  - **Use when**: [Situation]
+  - **Do not use when**: [Counter-condition]
+
+## Promoted Gotchas
+
+List failures, traps, or anti-patterns worth remembering before the next plan.
+
+- **Gotcha**: [Risk / trap]
+  - **Observed in**: [Story/Epic]
+  - **Prevention**: [What to do differently]
+
+## Retired / Invalidated Learnings
+
+Capture learnings that turned out to be wrong, outdated, or no longer applicable.
+
+- **Retired learning**: [What used to be believed]
+  - **Why retired**: [Why it no longer applies]
+  - **Superseded by**: [New learning / pattern]
+
+## Next Learnings to Test
+
+- [Hypothesis or pattern worth testing in the next story / epic]
+- [Open question that should be intentionally verified]

--- a/.speck/templates/project/project-retro-template.md
+++ b/.speck/templates/project/project-retro-template.md
@@ -169,6 +169,13 @@ specify → clarify → [ux] → context → [constitution] → architecture →
 
 ---
 
+## Promotion to Learnings Register
+
+Reconcile this retrospective against `learnings-register.md`:
+- promote durable project-local patterns
+- retire invalidated assumptions
+- identify which learnings should graduate into `.speck/patterns/learned/`
+
 ## Knowledge Base Built
 
 **Pattern Library Created**:

--- a/.speck/templates/story/story-retro-template.md
+++ b/.speck/templates/story/story-retro-template.md
@@ -76,6 +76,13 @@
 
 ---
 
+## Promotion to Learnings Register
+
+Update `learnings-register.md` for the parent project with:
+- any pattern worth intentionally reusing in the next story
+- any gotcha worth guarding against immediately
+- one hypothesis or learning that should be tested next
+
 ## Immediate Actions (Non-Meta - Applied to Current Epic)
 
 > **These updates were made during this retrospective**

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Your Speck project artifacts live under:
 specs/projects/[project-id]/
 ├── project.md          # Project vision & goals
 ├── PRD.md              # Product requirements
+├── learnings-register.md # Project-local learnings and validated gotchas
 ├── architecture.md     # System design
 └── epics/              # Epic specifications
     └── stories/        # Story specifications


### PR DESCRIPTION
## Summary
- add a project-local `learnings-register.md` template
- wire retrospectives and `/speck-learn` toward updating the learnings register
- document the relationship between project-local learnings and the shared learned-patterns library
- update project structure docs to include the new artifact

## Why
This gives Speck a durable project-local learning surface between one-off retrospective notes and fully promoted reusable patterns. It is the Speck-side adaptation of gstack's compounding repo-local learnings idea.

## Testing
- git diff --check
- verified register/propagation references via ripgrep
