### PR TITLE
Add review gauntlet and readiness scaffolding to Speck planning

### DIFF
--- a/.cursor/skills/epic-plan/SKILL.md
+++ b/.cursor/skills/epic-plan/SKILL.md
@@ -3,6 +3,10 @@ name: epic-plan
 description: Load after epic.md exists (and optional architecture/journey/wireframes) to produce epic-tech-spec.md with the full technical design. Required before epic-breakdown. Use when user says 'plan this epic' or 'write the tech spec'. FIRST ACTION after loading: read template at .speck/templates/epic/epic-tech-spec-template.md before any context loading or artifact generation.
 disable-model-invocation: false
 ---
+## Review gauntlet requirement
+
+When generating or updating `epic-tech-spec.md`, explicitly fill the **Review Gauntlet**, **Deferred Scope Register**, and **Review Readiness Dashboard** sections. The epic is not ready for story breakdown until those lanes are addressed.
+
 
 
 The user input to you can be provided directly by the agent or as a command argument - you **MUST** consider it before proceeding with the prompt (if not empty).

--- a/.cursor/skills/project-plan/SKILL.md
+++ b/.cursor/skills/project-plan/SKILL.md
@@ -3,6 +3,10 @@ name: project-plan
 description: Load after foundation artifacts exist (context.md for Build; architecture.md for Platform) to create PRD.md and the full epic structure. The central planning command — run before any epic work begins. Use when user says 'plan the project' or 'what are the epics?'. FIRST ACTION after loading: read templates at .speck/templates/project/prd-template.md and .speck/templates/project/epics-list-template.md before any context loading or artifact generation.
 disable-model-invocation: false
 ---
+## Review gauntlet requirement
+
+When generating or updating `PRD.md`, explicitly fill the **Review Gauntlet**, **Deferred Scope Register**, and **Review Readiness Dashboard** sections. The point is to make product, UX, engineering, and validation scrutiny visible before epic execution begins.
+
 
 
 The user input to you can be provided directly by the agent or as a command argument - you **MUST** consider it before proceeding with the prompt (if not empty).

--- a/.cursor/skills/story-plan/SKILL.md
+++ b/.cursor/skills/story-plan/SKILL.md
@@ -3,6 +3,10 @@ name: story-plan
 description: Load after spec.md (and optional clarify/outline/scan) to produce plan.md with the technical design, data model, contracts, and test strategy. Required before story-tasks. Use when user says 'plan this story', 'how should we build this?', or moves from spec to planning. FIRST ACTION after loading: read template at .speck/templates/story/plan-template.md before any context loading or artifact generation.
 disable-model-invocation: false
 ---
+## Review gauntlet requirement
+
+When generating or updating `plan.md`, explicitly fill the **Review Gauntlet**, **Deferred Scope Register**, and **Review Readiness Dashboard** sections. The story plan should show why it is ready for `/story-tasks`, not merely describe the code shape.
+
 
 
 The user input to you can be provided directly by the agent or as a command argument - you **MUST** consider it before proceeding with the prompt (if not empty).

--- a/.speck/templates/epic/epic-tech-spec-template.md
+++ b/.speck/templates/epic/epic-tech-spec-template.md
@@ -50,6 +50,33 @@ Derived from emotional targets and pain points in `user-journey.md`:
 
 ---
 
+## Review Gauntlet
+
+### 1. User Value / Scope Review
+
+- **Epic promise**: [What user-visible value this epic must deliver]
+- **Minimum lovable scope**: [What belongs in this epic vs what should wait]
+- **Scope expansions considered**: [Ideas surfaced during planning]
+- **Decision**: [Accepted / Deferred / Rejected with rationale]
+
+### 2. UX / Journey Review
+
+- **Critical user flow**: [What journey this epic owns]
+- **High-risk interaction states**: [Empty/loading/error/edge states that must be designed intentionally]
+- **Decision**: [What UX assumptions are locked before story breakdown]
+
+### 3. Engineering / Reliability Review
+
+- **Architectural pressure points**: [Boundaries, dependencies, failure modes]
+- **Operational risk**: [Data, jobs, migrations, auth, performance, rollback]
+- **Decision**: [What technical constraints or bets drive the approach]
+
+## Deferred Scope Register
+
+| Idea | Why it came up | Why it is deferred from this epic | Revisit trigger |
+|------|----------------|-----------------------------------|-----------------|
+| [Feature / expansion] | [Reason] | [Why not now] | [Condition] |
+
 ## Technical Approach
 
 Describe the end-to-end implementation approach for this epic:
@@ -136,6 +163,18 @@ This section guides `/epic-breakdown`:
 2. [Story name] — [Goal]
 
 ---
+
+## Review Readiness Dashboard
+
+| Review Lane | Status | Evidence / Artifact | Blocking? |
+|-------------|--------|---------------------|-----------|
+| User Value / Scope | [CLEAR / NEEDS WORK / N/A] | [Section, decision, or artifact] | [Yes/No] |
+| UX / Journey | [CLEAR / NEEDS WORK / N/A] | [Section, journey, or artifact] | [Yes/No] |
+| Engineering / Reliability | [CLEAR / NEEDS WORK / N/A] | [Section, architecture note, or artifact] | [Yes/No] |
+
+**Verdict**: [READY FOR STORY BREAKDOWN / HOLD]
+
+**Why**: [One paragraph on whether the epic is ready to break into stories]
 
 ## Open Questions / Risks
 

--- a/.speck/templates/project/prd-template.md
+++ b/.speck/templates/project/prd-template.md
@@ -99,6 +99,45 @@ Epic development (each epic references relevant sections)
 5. **Value Realization**: [When they see benefit]
 6. **Advocacy**: [How they share success]
 
+## Review Gauntlet
+
+### 1. Product / Scope Review
+
+- **Core user pain**: [What specific pain is sharp enough that this project deserves to exist?]
+- **Narrowest valuable wedge**: [What is the smallest version that still feels like the real product?]
+- **Why this now**: [Why should this be built now, not later?]
+- **Scope expansions considered**: [Expansion ideas considered during planning]
+- **Decision**: [Accepted / Deferred / Rejected with rationale]
+
+### 2. UX / Design Review
+
+- **Primary user journey**: [What must feel obvious and high-trust?]
+- **Critical states covered**: [Empty, loading, error, success, handoff, fallback]
+- **Design risk**: [Where could this become generic, confusing, or AI-sloppy?]
+- **Decision**: [What UX/design calls are locked before epic planning starts?]
+
+### 3. Engineering / Reliability Review
+
+- **System shape**: [What must already be true about architecture, integrations, data, auth, jobs, etc.?]
+- **Operational risk**: [Failure modes, rollout risk, migrations, external dependencies]
+- **Testing posture**: [How the project will prove correctness]
+- **Decision**: [What technical constraints shape the plan?]
+
+### 4. Validation / GTM Review
+
+- **Validation evidence**: [What evidence exists that this should be built?]
+- **Fastest learning loop**: [What should be tested in the market before expanding scope?]
+- **Ship gate**: [What would make the first release feel worth using or paying for?]
+- **Decision**: [What commercial/validation assumptions are carrying this plan?]
+
+## Deferred Scope Register
+
+Capture ideas that came up during planning but should NOT enter the first execution pass.
+
+| Idea | Why it came up | Why it is deferred now | Revisit trigger |
+|------|----------------|------------------------|-----------------|
+| [Feature / expansion] | [Reason] | [Scope, risk, sequencing, validation, etc.] | [Condition that would justify revisiting] |
+
 ## Functional Requirements
 
 ### Core Features
@@ -246,6 +285,21 @@ Epic development (each epic references relevant sections)
 - **Review Cycle**: [How often metrics reviewed]
 
 ## Risk Analysis
+
+## Review Readiness Dashboard
+
+Use this to make "how done is the plan?" explicit before implementation begins.
+
+| Review Lane | Status | Evidence / Artifact | Blocking? |
+|-------------|--------|---------------------|-----------|
+| Product / Scope | [CLEAR / NEEDS WORK / N/A] | [Section, doc, or decision note] | [Yes/No] |
+| UX / Design | [CLEAR / NEEDS WORK / N/A] | [Section, doc, or decision note] | [Yes/No] |
+| Engineering / Reliability | [CLEAR / NEEDS WORK / N/A] | [Section, doc, or decision note] | [Yes/No] |
+| Validation / GTM | [CLEAR / NEEDS WORK / N/A] | [Section, doc, or decision note] | [Yes/No] |
+
+**Verdict**: [READY FOR EPIC PLANNING / HOLD]
+
+**Why**: [One paragraph on why the project should proceed now or what must be fixed first]
 
 ### Risk Matrix
 

--- a/.speck/templates/story/plan-template.md
+++ b/.speck/templates/story/plan-template.md
@@ -41,6 +41,33 @@
 
 ---
 
+## Review Gauntlet
+
+### 1. User Outcome / Scope Review
+
+- **Story promise**: [What becomes true for the user after this story ships]
+- **Minimum correct scope**: [What is in vs out for this story]
+- **Scope expansions considered**: [Ideas surfaced while planning]
+- **Decision**: [Accepted / Deferred / Rejected with rationale]
+
+### 2. UX / Interaction Review
+
+- **Critical state coverage**: [Empty, loading, error, success, edge states]
+- **High-risk UX detail**: [What could feel cheap, confusing, or brittle]
+- **Decision**: [What UX details must be preserved during implementation]
+
+### 3. Engineering / Reliability Review
+
+- **Failure modes**: [What can break and how the design contains it]
+- **Test posture**: [How this story proves correctness]
+- **Decision**: [What technical guardrails or constraints matter most]
+
+## Deferred Scope Register
+
+| Idea | Why it came up | Why it is deferred from this story | Revisit trigger |
+|------|----------------|------------------------------------|-----------------|
+| [Change / improvement] | [Reason] | [Why not now] | [Condition] |
+
 ## Technical Approach
 [Describe HOW this story will be implemented at a high level: main components touched, key patterns reused, and key decisions/trade-offs. Keep this 3–8 sentences.]
 
@@ -392,6 +419,18 @@ directories captured above]
 **Phase 3**: Task generation (/story-tasks command creates tasks.md)  
 **Phase 4**: Implementation (/story-implement executes tasks.md)  
 **Phase 5**: Validation (/story-validate runs tests, validates requirements, generates reports)
+
+## Review Readiness Dashboard
+
+| Review Lane | Status | Evidence / Artifact | Blocking? |
+|-------------|--------|---------------------|-----------|
+| User Outcome / Scope | [CLEAR / NEEDS WORK / N/A] | [Section, spec link, or note] | [Yes/No] |
+| UX / Interaction | [CLEAR / NEEDS WORK / N/A] | [Section, ui-spec, or note] | [Yes/No] |
+| Engineering / Reliability | [CLEAR / NEEDS WORK / N/A] | [Section, tests, or note] | [Yes/No] |
+
+**Verdict**: [READY FOR /story-tasks / HOLD]
+
+**Why**: [One paragraph on whether planning is strong enough to move into tasks]
 
 ## Complexity Tracking
 *Fill ONLY if Constitution Check has violations that must be justified*

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Your Speck project artifacts live under:
 specs/projects/[project-id]/
 ├── project.md          # Project vision & goals
 ├── PRD.md              # Product requirements
+├── review-readiness.md # Optional: consolidated review/readiness snapshot
 ├── architecture.md     # System design
 └── epics/              # Epic specifications
     └── stories/        # Story specifications


### PR DESCRIPTION
## Summary
- add explicit review gauntlet sections to project, epic, and story planning templates
- add deferred scope registers so planning captures good ideas without scope sprawl
- add review readiness dashboards so plans show whether they are ready to move to the next stage
- update planning skills and project structure docs to reflect the new planning contract

## Why
This adapts the strongest structural idea from gstack into Speck: planning should not be a single blob. Product, UX, engineering, and readiness scrutiny should be explicit before implementation begins.

## Testing
- git diff --check
- verified template/skill references via ripgrep
